### PR TITLE
Fix problem with Arrays of ModelTypes in fromJS

### DIFF
--- a/examples/foo.js
+++ b/examples/foo.js
@@ -35,7 +35,7 @@ export class Foo extends ImmutableModel {
     const state = Object.assign({}, defaultFooValues, json);
 
     state.bar = Bar.fromJS(state.bar);
-    state.barAry = state.barAry.map(item => item.fromJS(item));
+    state.barAry = state.barAry.map(item => Bar.fromJS(item));
     return new Foo(Immutable.fromJS(state));
   }
 

--- a/src/helpers/fromJS.js
+++ b/src/helpers/fromJS.js
@@ -2,7 +2,7 @@
 import getTypeAnnotationWithoutInterface from './getTypeAnnotationWithoutModelType';
 import isImmutableType from './isImmutableType';
 import typeToExpression from './typeToExpression';
-import { endsWithModelType } from './withoutModelTypeSuffix';
+import { endsWithModelType, withoutModelTypeSuffix } from './withoutModelTypeSuffix';
 
 function getParamTypeAnnotation(j, className, defaultValues) {
   if (defaultValues) {
@@ -58,6 +58,8 @@ export default function fromJS(
       );
 
       if (typeAlias.id.name === 'Array') {
+        const modelType = typeAlias.typeParameters.params[0].id.name;
+        const nonModelType = withoutModelTypeSuffix(modelType);
         valueExpression = j.callExpression(
           j.memberExpression(
             propExpression,
@@ -69,7 +71,7 @@ export default function fromJS(
                 j.identifier('item'),
               ],
               j.callExpression(
-                j.memberExpression(j.identifier('item'), j.identifier('fromJS')),
+                j.memberExpression(j.identifier(nonModelType), j.identifier('fromJS')),
                 [j.identifier('item')]
               )
             ),


### PR DESCRIPTION
Given...

```
export type FooModelType = {
  barAry: Array<BarModelType>,
};

```

Original code was generating...
```
  static fromJS(json: $Diff<FooModelType, typeof defaultFooValues>): Foo {
    // [...]
    state.barAry = state.barAry.map(item => item.fromJS(item));
    // [...]
  }
```

When invoking `Foo.fromJS` and passing in `{ barAry: [{...}] }`, code would throw error, `item.fromJS is not a function`.

New code correctly(?) generates...
```
  static fromJS(json: $Diff<FooModelType, typeof defaultFooValues>): Foo {
    // [...]
    state.barAry = state.barAry.map(item => Bar.fromJS(item));
    // [...]
  }
```