### PR TITLE
Automatic import for necessary packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 node_modules
 npm-debug.log
 lib

--- a/examples/bar.js
+++ b/examples/bar.js
@@ -14,7 +14,7 @@ export const defaultBarValues: BarModelType = {
 
 ////////////////////////////////////////////////////////////////////////////////
 //
-// NOTE: THIS CLASS IS GENERATED. DO NOT MAKE CHANGES HERE.
+// NOTE: EVERYTHING BELOW THIS COMMENT IS GENERATED. DO NOT MAKE CHANGES HERE.
 //
 // If you need to update this class, update the corresponding flow type above
 // and re-run the flow-immutable-models codemod

--- a/examples/baz.js
+++ b/examples/baz.js
@@ -14,7 +14,7 @@ export type InnerBazModelType = {
 
 ////////////////////////////////////////////////////////////////////////////////
 //
-// NOTE: THIS CLASS IS GENERATED. DO NOT MAKE CHANGES HERE.
+// NOTE: EVERYTHING BELOW THIS COMMENT IS GENERATED. DO NOT MAKE CHANGES HERE.
 //
 // If you need to update this class, update the corresponding flow type above
 // and re-run the flow-immutable-models codemod
@@ -44,14 +44,6 @@ export class Baz extends ImmutableModel {
   }
 }
 
-////////////////////////////////////////////////////////////////////////////////
-//
-// NOTE: THIS CLASS IS GENERATED. DO NOT MAKE CHANGES HERE.
-//
-// If you need to update this class, update the corresponding flow type above
-// and re-run the flow-immutable-models codemod
-//
-////////////////////////////////////////////////////////////////////////////////
 export class InnerBaz extends ImmutableModel {
   static fromJS(json: InnerBazModelType): InnerBaz {
     const state = Object.assign({}, json);

--- a/examples/baz.js
+++ b/examples/baz.js
@@ -3,8 +3,8 @@ import * as Immutable from 'immutable';
 import ImmutableModel from '../src/ImmutableModel';
 
 export type BazModelType = {
-  bazNum: number,
-  innerBazs: Array<InnerBazModelType>,
+  num: number,
+  innerBazAry: Array<InnerBazModelType>,
 };
 
 export type InnerBazModelType = {
@@ -23,24 +23,24 @@ export type InnerBazModelType = {
 export class Baz extends ImmutableModel {
   static fromJS(json: BazModelType): Baz {
     const state = Object.assign({}, json);
-    state.innerBazs = state.innerBazs.map(item => InnerBaz.fromJS(item));
+    state.innerBazAry = state.innerBazAry.map(item => InnerBaz.fromJS(item));
     return new Baz(Immutable.fromJS(state));
   }
 
-  get bazNum(): number {
-    return this._state.get('bazNum');
+  get num(): number {
+    return this._state.get('num');
   }
 
-  setBazNum(bazNum: number): Baz {
-    return new Baz(this._state.set('bazNum', bazNum));
+  setNum(num: number): Baz {
+    return new Baz(this._state.set('num', num));
   }
 
-  get innerBazs(): Immutable.List<InnerBaz> {
-    return this._state.get('innerBazs');
+  get innerBazAry(): Immutable.List<InnerBaz> {
+    return this._state.get('innerBazAry');
   }
 
-  setInnerBazs(innerBazs: Immutable.List<InnerBaz>): Baz {
-    return new Baz(this._state.set('innerBazs', innerBazs));
+  setInnerBazAry(innerBazAry: Immutable.List<InnerBaz>): Baz {
+    return new Baz(this._state.set('innerBazAry', innerBazAry));
   }
 }
 

--- a/examples/foo.js
+++ b/examples/foo.js
@@ -23,7 +23,7 @@ const defaultFooValues: $Shape<FooModelType> = {
 
 ////////////////////////////////////////////////////////////////////////////////
 //
-// NOTE: THIS CLASS IS GENERATED. DO NOT MAKE CHANGES HERE.
+// NOTE: EVERYTHING BELOW THIS COMMENT IS GENERATED. DO NOT MAKE CHANGES HERE.
 //
 // If you need to update this class, update the corresponding flow type above
 // and re-run the flow-immutable-models codemod

--- a/examples/quux.js
+++ b/examples/quux.js
@@ -1,0 +1,40 @@
+// @flow
+export type QuuxModelType = {
+  id: number,
+  name: string,
+};
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// NOTE: EVERYTHING BELOW THIS COMMENT IS GENERATED. DO NOT MAKE CHANGES HERE.
+//
+// If you need to update this class, update the corresponding flow type above
+// and re-run the flow-immutable-models codemod
+//
+////////////////////////////////////////////////////////////////////////////////
+import * as Immutable from 'immutable';
+
+import ImmutableModel from 'flow-immutable-models';
+
+export class Quux extends ImmutableModel {
+  static fromJS(json: QuuxModelType): Quux {
+    const state = Object.assign({}, json);
+    return new Quux(Immutable.fromJS(state));
+  }
+
+  get id(): number {
+    return this._state.get('id');
+  }
+
+  setId(id: number): Quux {
+    return new Quux(this._state.set('id', id));
+  }
+
+  get name(): string {
+    return this._state.get('name');
+  }
+
+  setName(name: string): Quux {
+    return new Quux(this._state.set('name', name));
+  }
+}

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -8,7 +8,7 @@ export type UserModelType = {
 
 ////////////////////////////////////////////////////////////////////////////////
 //
-// NOTE: THIS CLASS IS GENERATED. DO NOT MAKE CHANGES HERE.
+// NOTE: EVERYTHING BELOW THIS COMMENT IS GENERATED. DO NOT MAKE CHANGES HERE.
 //
 // If you need to update this class, update the corresponding flow type above
 // and re-run the flow-immutable-models codemod

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -1,9 +1,8 @@
+// @flow
 import * as Immutable from 'immutable';
-import ImmutableModel from 'flow-immutable-models';
 
-export type UserModelType = {
-  id: number,
-  name: string,
+export type SimpleModelType = {
+  simpleNumber: number,
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -14,25 +13,19 @@ export type UserModelType = {
 // and re-run the flow-immutable-models codemod
 //
 ////////////////////////////////////////////////////////////////////////////////
-export class User extends ImmutableModel {
-  static fromJS(json: UserModelType): User {
+import ImmutableModel from 'flow-immutable-models';
+
+export class Simple extends ImmutableModel {
+  static fromJS(json: SimpleModelType): Simple {
     const state = Object.assign({}, json);
-    return new User(Immutable.fromJS(state));
+    return new Simple(Immutable.fromJS(state));
   }
 
-  get id(): number {
-    return this._state.get('id');
+  get simpleNumber(): number {
+    return this._state.get('simpleNumber');
   }
 
-  setId(id: number): User {
-    return new User(this._state.set('id', id));
-  }
-
-  get name(): string {
-    return this._state.get('name');
-  }
-
-  setName(name: string): User {
-    return new User(this._state.set('name', name));
+  setSimpleNumber(simpleNumber: number): Simple {
+    return new Simple(this._state.set('simpleNumber', simpleNumber));
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "babel src -d lib",
     "flow": "flow",
     "eslint": "eslint src",
-    "prepublish": "npm run eslint && npm run flow && npm test &&  npm run build",
+    "prepublish": "npm run eslint && npm run flow && npm test && npm run build",
     "test": "jest"
   },
   "keywords": [

--- a/src/__tests__/__snapshots__/transform.spec.js.snap
+++ b/src/__tests__/__snapshots__/transform.spec.js.snap
@@ -19,7 +19,7 @@ export type FooModelType = {
 
 ////////////////////////////////////////////////////////////////////////////////
 //
-// NOTE: THIS CLASS IS GENERATED. DO NOT MAKE CHANGES HERE.
+// NOTE: EVERYTHING BELOW THIS COMMENT IS GENERATED. DO NOT MAKE CHANGES HERE.
 //
 // If you need to update this class, update the corresponding flow type above
 // and re-run the flow-immutable-models codemod
@@ -126,7 +126,7 @@ export type ArrModelType = {
 
 ////////////////////////////////////////////////////////////////////////////////
 //
-// NOTE: THIS CLASS IS GENERATED. DO NOT MAKE CHANGES HERE.
+// NOTE: EVERYTHING BELOW THIS COMMENT IS GENERATED. DO NOT MAKE CHANGES HERE.
 //
 // If you need to update this class, update the corresponding flow type above
 // and re-run the flow-immutable-models codemod
@@ -171,7 +171,7 @@ export type FooModelType = {
 
 ////////////////////////////////////////////////////////////////////////////////
 //
-// NOTE: THIS CLASS IS GENERATED. DO NOT MAKE CHANGES HERE.
+// NOTE: EVERYTHING BELOW THIS COMMENT IS GENERATED. DO NOT MAKE CHANGES HERE.
 //
 // If you need to update this class, update the corresponding flow type above
 // and re-run the flow-immutable-models codemod
@@ -222,7 +222,7 @@ export type NonClassImportedModelType = {
 
 ////////////////////////////////////////////////////////////////////////////////
 //
-// NOTE: THIS CLASS IS GENERATED. DO NOT MAKE CHANGES HERE.
+// NOTE: EVERYTHING BELOW THIS COMMENT IS GENERATED. DO NOT MAKE CHANGES HERE.
 //
 // If you need to update this class, update the corresponding flow type above
 // and re-run the flow-immutable-models codemod
@@ -259,7 +259,7 @@ export type NonClassModelType = {
 
 ////////////////////////////////////////////////////////////////////////////////
 //
-// NOTE: THIS CLASS IS GENERATED. DO NOT MAKE CHANGES HERE.
+// NOTE: EVERYTHING BELOW THIS COMMENT IS GENERATED. DO NOT MAKE CHANGES HERE.
 //
 // If you need to update this class, update the corresponding flow type above
 // and re-run the flow-immutable-models codemod
@@ -306,7 +306,7 @@ export type FooModelType = {
 
 ////////////////////////////////////////////////////////////////////////////////
 //
-// NOTE: THIS CLASS IS GENERATED. DO NOT MAKE CHANGES HERE.
+// NOTE: EVERYTHING BELOW THIS COMMENT IS GENERATED. DO NOT MAKE CHANGES HERE.
 //
 // If you need to update this class, update the corresponding flow type above
 // and re-run the flow-immutable-models codemod
@@ -365,7 +365,7 @@ export type ArrModelType = {
 
 ////////////////////////////////////////////////////////////////////////////////
 //
-// NOTE: THIS CLASS IS GENERATED. DO NOT MAKE CHANGES HERE.
+// NOTE: EVERYTHING BELOW THIS COMMENT IS GENERATED. DO NOT MAKE CHANGES HERE.
 //
 // If you need to update this class, update the corresponding flow type above
 // and re-run the flow-immutable-models codemod

--- a/src/__tests__/__snapshots__/transform.spec.js.snap
+++ b/src/__tests__/__snapshots__/transform.spec.js.snap
@@ -25,6 +25,8 @@ export type FooModelType = {
 // and re-run the flow-immutable-models codemod
 //
 ////////////////////////////////////////////////////////////////////////////////
+import * as Immutable from \'immutable\';
+
 export class Foo extends ImmutableModel {
   static fromJS(json: FooModelType): Foo {
     const state = Object.assign({}, json);
@@ -132,6 +134,8 @@ export type ArrModelType = {
 // and re-run the flow-immutable-models codemod
 //
 ////////////////////////////////////////////////////////////////////////////////
+import * as Immutable from \'immutable\';
+
 export class Arr extends ImmutableModel {
   static fromJS(json: ArrModelType): Arr {
     const state = Object.assign({}, json);
@@ -177,6 +181,8 @@ export type FooModelType = {
 // and re-run the flow-immutable-models codemod
 //
 ////////////////////////////////////////////////////////////////////////////////
+import * as Immutable from \'immutable\';
+
 export class Foo extends ImmutableModel {
   static fromJS(json: FooModelType): Foo {
     const state = Object.assign({}, json);
@@ -228,6 +234,8 @@ export type NonClassImportedModelType = {
 // and re-run the flow-immutable-models codemod
 //
 ////////////////////////////////////////////////////////////////////////////////
+import * as Immutable from \'immutable\';
+
 export class NonClassImported extends ImmutableModel {
   static fromJS(json: NonClassImportedModelType): NonClassImported {
     const state = Object.assign({}, json);
@@ -265,6 +273,8 @@ export type NonClassModelType = {
 // and re-run the flow-immutable-models codemod
 //
 ////////////////////////////////////////////////////////////////////////////////
+import * as Immutable from \'immutable\';
+
 export class NonClass extends ImmutableModel {
   static fromJS(json: NonClassModelType): NonClass {
     const state = Object.assign({}, json);
@@ -371,6 +381,8 @@ export type ArrModelType = {
 // and re-run the flow-immutable-models codemod
 //
 ////////////////////////////////////////////////////////////////////////////////
+import * as Immutable from \'immutable\';
+
 export class Arr extends ImmutableModel {
   static fromJS(json: ArrModelType): Arr {
     const state = Object.assign({}, json);
@@ -384,6 +396,159 @@ export class Arr extends ImmutableModel {
 
   setArr(arr: Immutable.List<Bar>): Arr {
     return new Arr(this._state.set(\'arr\', arr));
+  }
+}
+"
+`;
+
+exports[`transform initializes arrays of other model types 2`] = `
+"// @flow
+import ImmutableModel from \'../../../src/ImmutableModel\';
+import { Bar } from \'./bar\';
+import type { BarModelType } from \'./bar\';
+
+export type ArrModelType = {
+  arr: Array<BarModelType>,
+};
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// NOTE: EVERYTHING BELOW THIS COMMENT IS GENERATED. DO NOT MAKE CHANGES HERE.
+//
+// If you need to update this class, update the corresponding flow type above
+// and re-run the flow-immutable-models codemod
+//
+////////////////////////////////////////////////////////////////////////////////
+import * as Immutable from \'immutable\';
+
+export class Arr extends ImmutableModel {
+  static fromJS(json: ArrModelType): Arr {
+    const state = Object.assign({}, json);
+    state.arr = state.arr.map(item => Bar.fromJS(item));
+    return new Arr(Immutable.fromJS(state));
+  }
+
+  get arr(): Immutable.List<Bar> {
+    return this._state.get(\'arr\');
+  }
+
+  setArr(arr: Immutable.List<Bar>): Arr {
+    return new Arr(this._state.set(\'arr\', arr));
+  }
+}
+"
+`;
+
+exports[`transform provides default values 1`] = `
+"// @flow
+import * as Immutable from \'immutable\';
+import type { BarModelType } from \'./bar\';
+import { defaultBarValues } from \'./bar\';
+
+export type DefaultsModelType = {
+  str: string,
+  num: number,
+  bool: boolean,
+  bar: BarModelType,
+  barAry: Array<BarModelType>,
+  regArray: Array<boolean>,
+  lst: Immutable.List<BarModelType>,
+  maap: Immutable.Map<string, any>,
+};
+
+const defaultDefaultsValues: $Shape<DefaultsModelType> = {
+  str: \'strInitial\',
+  num: 42,
+  bool: true,
+  bar: defaultBarValues,
+  barAry: undefined,
+  regArray: [false, true, false],
+  lst: Immutable.List(),
+  maap: Immutable.Map(),
+};
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// NOTE: EVERYTHING BELOW THIS COMMENT IS GENERATED. DO NOT MAKE CHANGES HERE.
+//
+// If you need to update this class, update the corresponding flow type above
+// and re-run the flow-immutable-models codemod
+//
+////////////////////////////////////////////////////////////////////////////////
+import ImmutableModel from \'flow-immutable-models\';
+
+export class Defaults extends ImmutableModel {
+  static fromJS(json: $Diff<DefaultsModelType, typeof defaultDefaultsValues>): Defaults {
+    // $FlowFixMe
+    const state = Object.assign({}, defaultDefaultsValues, json);
+
+    state.bar = Bar.fromJS(state.bar);
+    state.barAry = state.barAry.map(item => Bar.fromJS(item));
+    return new Defaults(Immutable.fromJS(state));
+  }
+
+  get str(): string {
+    return this._state.get(\'str\');
+  }
+
+  setStr(str: string): Defaults {
+    return new Defaults(this._state.set(\'str\', str));
+  }
+
+  get num(): number {
+    return this._state.get(\'num\');
+  }
+
+  setNum(num: number): Defaults {
+    return new Defaults(this._state.set(\'num\', num));
+  }
+
+  get bool(): boolean {
+    return this._state.get(\'bool\');
+  }
+
+  setBool(bool: boolean): Defaults {
+    return new Defaults(this._state.set(\'bool\', bool));
+  }
+
+  get bar(): Bar {
+    return this._state.get(\'bar\');
+  }
+
+  setBar(bar: Bar): Defaults {
+    return new Defaults(this._state.set(\'bar\', bar));
+  }
+
+  get barAry(): Immutable.List<Bar> {
+    return this._state.get(\'barAry\');
+  }
+
+  setBarAry(barAry: Immutable.List<Bar>): Defaults {
+    return new Defaults(this._state.set(\'barAry\', barAry));
+  }
+
+  get regArray(): Immutable.List<boolean> {
+    return this._state.get(\'regArray\');
+  }
+
+  setRegArray(regArray: Immutable.List<boolean>): Defaults {
+    return new Defaults(this._state.set(\'regArray\', regArray));
+  }
+
+  get lst(): Immutable.List<Bar> {
+    return this._state.get(\'lst\');
+  }
+
+  setLst(lst: Immutable.List<Bar>): Defaults {
+    return new Defaults(this._state.set(\'lst\', lst));
+  }
+
+  get maap(): Immutable.Map<string, any> {
+    return this._state.get(\'maap\');
+  }
+
+  setMaap(maap: Immutable.Map<string, any>): Defaults {
+    return new Defaults(this._state.set(\'maap\', maap));
   }
 }
 "

--- a/src/__tests__/fixtures/defaults.js
+++ b/src/__tests__/fixtures/defaults.js
@@ -1,0 +1,26 @@
+// @flow
+import * as Immutable from 'immutable';
+import type { BarModelType } from './bar';
+import { defaultBarValues } from './bar';
+
+export type DefaultsModelType = {
+  str: string,
+  num: number,
+  bool: boolean,
+  bar: BarModelType,
+  barAry: Array<BarModelType>,
+  regArray: Array<boolean>,
+  lst: Immutable.List<BarModelType>,
+  maap: Immutable.Map<string, any>,
+};
+
+const defaultDefaultsValues: $Shape<DefaultsModelType> = {
+  str: 'strInitial',
+  num: 42,
+  bool: true,
+  bar: defaultBarValues,
+  barAry: undefined,
+  regArray: [false, true, false],
+  lst: Immutable.List(),
+  maap: Immutable.Map(),
+};

--- a/src/__tests__/transform.spec.js
+++ b/src/__tests__/transform.spec.js
@@ -34,4 +34,12 @@ describe('transform', () => {
   it('initializes arrays of other model types', async () => {
     await snap('arrayOfModelType.js');
   });
+
+  it('provides default values', async () => {
+    await snap('defaults.js');
+  });
+
+  it('initializes arrays of other model types', async () => {
+    await snap('arrayOfModelType.js');
+  });
 });

--- a/src/transform.js
+++ b/src/transform.js
@@ -25,14 +25,15 @@ export default function(file: Object, api: Object, options: Object) {
 
   const root = j(file.source);
   const { program } = root.get().value;
-  const { body } = program;
-
+  let { body } = program;
   let hasAppliedCutlineComment = false;
 
-  const classes: Array<{|
-    className: string,
-    classDef: Array<Object>
-  |}> = [];
+  function nodeHasCutlineComment(node): bool {
+    return node &&
+      node.comments &&
+      node.comments.length === comments.length &&
+      node.comments.every((c, i) => comments[i] === c.value);
+  }
 
   function prependCutlineCommentBlockOnce(): ?Array<Object> {
     if (!hasAppliedCutlineComment) {
@@ -71,7 +72,7 @@ export default function(file: Object, api: Object, options: Object) {
       )
     );
     classDeclaration.comments = prependCutlineCommentBlockOnce();
-    return [classDeclaration];
+    return classDeclaration;
   }
 
   function parseType(td: Object) {
@@ -101,6 +102,49 @@ export default function(file: Object, api: Object, options: Object) {
     return typeDef;
   }
 
+  let keep = true;
+  body = body
+    .filter((n) => {
+      keep = keep && !nodeHasCutlineComment(n);
+      return keep;
+    });
+
+  let insertImmutableImport = true;
+  let insertImmutableModelImport = true;
+  body
+    .forEach((p) => {
+      if (p.type !== 'ImportDeclaration') {
+        return;
+      }
+      p.specifiers.forEach((s) => {
+        if (s.local.name === 'Immutable') {
+          insertImmutableImport = false;
+        } else if (s.local.name === 'ImmutableModel') {
+          insertImmutableModelImport = false;
+        }
+      });
+    });
+
+  if (insertImmutableImport) {
+    const nameIdentifier = j.identifier('Immutable');
+    const variable = j.importNamespaceSpecifier(nameIdentifier);
+    const declaration = j.importDeclaration([variable], j.literal('immutable'));
+
+    declaration.comments = prependCutlineCommentBlockOnce();
+
+    body.push(declaration);
+  }
+
+  if (insertImmutableModelImport) {
+    const nameIdentifier = j.identifier('ImmutableModel');
+    const variable = j.importDefaultSpecifier(nameIdentifier);
+    const declaration = j.importDeclaration([variable], j.literal('flow-immutable-models'));
+
+    declaration.comments = prependCutlineCommentBlockOnce();
+
+    body.push(declaration);
+  }
+
   root
     .find(j.ExportNamedDeclaration)
     .filter((p) => {
@@ -121,27 +165,13 @@ export default function(file: Object, api: Object, options: Object) {
           path.node.declarations.some(dec => dec.id.name === defaultValuesName)
         );
 
-      classes.push({
+      body.push(makeClass(
         className,
-        classDef: makeClass(
-          className,
-          parsed,
-          defaultValues.size() === 1 ? defaultValuesName : null
-        ),
-      });
+        parsed,
+        defaultValues.size() === 1 ? defaultValuesName : null
+      ));
     });
 
-  classes.forEach(({ className, classDef }) => {
-    const alreadyExportedClass = root
-      .find(j.ExportNamedDeclaration)
-      .filter(path => path.node.declaration.type === 'ClassDeclaration' && path.node.declaration.id.name === className);
-
-    if (alreadyExportedClass.size() === 1) {
-      alreadyExportedClass.replaceWith(classDef);
-    } else {
-      body.push(...classDef);
-    }
-  });
-
+  root.get().value.program.body = body;
   return root.toSource(printOptions);
 }

--- a/src/transform.js
+++ b/src/transform.js
@@ -6,6 +6,16 @@ import getter from './helpers/getter';
 import setter from './helpers/setter';
 import { endsWithModelType, withoutModelTypeSuffix } from './helpers/withoutModelTypeSuffix';
 
+const comments = [
+  '//////////////////////////////////////////////////////////////////////////////',
+  '',
+  ' NOTE: EVERYTHING BELOW THIS COMMENT IS GENERATED. DO NOT MAKE CHANGES HERE.',
+  '',
+  ' If you need to update this class, update the corresponding flow type above',
+  ' and re-run the flow-immutable-models codemod',
+  '',
+  '//////////////////////////////////////////////////////////////////////////////',
+];
 const defaultPrintOptions = { quote: 'single', trailingComma: true };
 
 export default function(file: Object, api: Object, options: Object) {
@@ -17,10 +27,20 @@ export default function(file: Object, api: Object, options: Object) {
   const { program } = root.get().value;
   const { body } = program;
 
+  let hasAppliedCutlineComment = false;
+
   const classes: Array<{|
     className: string,
     classDef: Array<Object>
   |}> = [];
+
+  function prependCutlineCommentBlockOnce(): ?Array<Object> {
+    if (!hasAppliedCutlineComment) {
+      hasAppliedCutlineComment = true;
+      return comments.map(comment => j.commentLine(comment));
+    }
+    return undefined;
+  }
 
   function makeClass(className, type, defaultValues) {
     const classNameIdentifier = j.identifier(className);
@@ -50,17 +70,7 @@ export default function(file: Object, api: Object, options: Object) {
         j.identifier('ImmutableModel')
       )
     );
-    const comments = [
-      '//////////////////////////////////////////////////////////////////////////////',
-      '',
-      ' NOTE: THIS CLASS IS GENERATED. DO NOT MAKE CHANGES HERE.',
-      '',
-      ' If you need to update this class, update the corresponding flow type above',
-      ' and re-run the flow-immutable-models codemod',
-      '',
-      '//////////////////////////////////////////////////////////////////////////////',
-    ];
-    classDeclaration.comments = comments.map(comment => j.commentLine(comment));
+    classDeclaration.comments = prependCutlineCommentBlockOnce();
     return [classDeclaration];
   }
 


### PR DESCRIPTION
Addressing #4, this PR does several things:

1) Treats all code attached to and below the "cutline" comment as disposable, and will be removed and regenerated entirely when the model is rebuilt.
2) If the reference to ImmutableModel is missing, it will be added, below the cutline.
3) If the reference to `* as Immutable` is missing, it will be added, below the cutline.

There's some refactoring that could be done.